### PR TITLE
fix: null handling

### DIFF
--- a/callable.go
+++ b/callable.go
@@ -518,7 +518,6 @@ func (f *lambdaCallable) validateArgTypes(argv []reflect.Value) ([]reflect.Value
 	paramCount := len(f.params)
 
 	for i, arg := range argv {
-
 		// Don't type check undefined arguments.
 		if arg == undefined {
 			continue

--- a/eval_test.go
+++ b/eval_test.go
@@ -75,7 +75,7 @@ func TestEvalNull(t *testing.T) {
 	testEvalTestCases(t, []evalTestCase{
 		{
 			Input:  &jparse.NullNode{},
-			Output: null,
+			Output: nil,
 		},
 	})
 }
@@ -624,7 +624,7 @@ func TestEvalArray(t *testing.T) {
 				float64(1),
 				"two",
 				true,
-				null,
+				nil,
 			},
 		},
 		{
@@ -654,7 +654,7 @@ func TestEvalArray(t *testing.T) {
 					"two",
 					true,
 				},
-				null,
+				nil,
 			},
 		},
 		{

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/stepzen-dev/jsonata-go
 
 go 1.20
 
-require golang.org/x/text v0.9.0
+require (
+	github.com/stretchr/testify v1.8.4
+	golang.org/x/text v0.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/jsonata_test.go
+++ b/jsonata_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stepzen-dev/jsonata-go/jparse"
 	"github.com/stepzen-dev/jsonata-go/jtypes"
+	"github.com/stretchr/testify/require"
 )
 
 type testCase struct {
@@ -300,8 +301,12 @@ func TestPaths2(t *testing.T) {
 			Output:     map[string]any{"misc": nil},
 		},
 		{
-			Expression: `[4, null, Other.Misc]`,
-			Output:     []any{4, nil, nil},
+			Expression: `["abc", null, Other.Misc]`,
+			Output:     []any{"abc", nil, nil},
+		},
+		{
+			Expression: `null`,
+			Output:     nil,
 		},
 	})
 }
@@ -2796,7 +2801,6 @@ func TestNullExpressions(t *testing.T) {
 			Output: []interface{}{
 				nil,
 			},
-			Skip: true, // uses the wrong kind of nil (*interface{}(nil) instead of plain nil)?
 		},
 		{
 			Expression: "[null, null]",
@@ -2804,7 +2808,6 @@ func TestNullExpressions(t *testing.T) {
 				nil,
 				nil,
 			},
-			Skip: true, // uses the wrong kind of nil (*interface{}(nil) instead of plain nil)?
 		},
 		{
 			Expression: "$not(null)",
@@ -2825,7 +2828,6 @@ func TestNullExpressions(t *testing.T) {
 				"false": false,
 				"null":  nil,
 			},
-			Skip: true, // uses the wrong kind of nil (*interface{}(nil) instead of plain nil)?
 		},
 	})
 }
@@ -8115,4 +8117,12 @@ func readJSON(filename string) interface{} {
 	}
 
 	return dest
+}
+
+func TestNullValue(t *testing.T) {
+	nv := nullValue()
+	require.True(t, nv.IsValid())
+	require.True(t, nv.IsNil())
+	require.True(t, nv.CanInterface())
+	require.True(t, nv.Interface() == nil)
 }

--- a/jsonata_test.go
+++ b/jsonata_test.go
@@ -285,12 +285,23 @@ func TestPaths(t *testing.T) {
 }
 
 func TestPaths2(t *testing.T) {
-
 	runTestCases(t, testdata.address, []*testCase{
 		{
 			Expression: "Other.Misc",
 			Output:     nil,
-			Skip:       true, // returns ErrUndefined
+		},
+		{
+			Expression: "Other.XXX", // no such key
+			Output:     nil,
+			Error:      ErrUndefined,
+		},
+		{
+			Expression: `{"misc": Other.Misc}`,
+			Output:     map[string]any{"misc": nil},
+		},
+		{
+			Expression: `[4, null, Other.Misc]`,
+			Output:     []any{4, nil, nil},
 		},
 	})
 }


### PR DESCRIPTION
 Represents null as a `reflect.Value` that has `IsValid` and `IsNil` returning true.
Previously either a value of `*interface{}(nil)` or an invalid value was used, leading to confusion with `undefined` and skipped tests.