### PR TITLE
fix: don't share a base env across all executions

### DIFF
--- a/env.go
+++ b/env.go
@@ -65,7 +65,7 @@ var (
 	argCountEquals1 = jtypes.ArgCountEquals(1)
 )
 
-var baseEnv = initBaseEnv(map[string]Extension{
+var standardFunctions = map[string]Extension{
 
 	// String functions
 
@@ -385,7 +385,7 @@ var baseEnv = initBaseEnv(map[string]Extension{
 		UndefinedHandler:   nil,
 		EvalContextHandler: nil,
 	},
-})
+}
 
 func initBaseEnv(exts map[string]Extension) *environment {
 

--- a/jsonata.go
+++ b/jsonata.go
@@ -232,7 +232,9 @@ func (e *Expr) newEnv(input reflect.Value) *environment {
 
 	tc := timeCallables(time.Now())
 
-	env := newEnvironment(baseEnv, len(tc)+len(e.registry)+1)
+	// create a new base environment (with the standard functions) to
+	// ensure each execution gets its own set of goCallables for functions.
+	env := newEnvironment(initBaseEnv(standardFunctions), len(tc)+len(e.registry)+1)
 
 	env.bind("$", input)
 	env.bindAll(tc)


### PR DESCRIPTION
Test fails without change and running all tests with `-race` fails without change.

Create a new base environment for each `Eval` call.

Test passes and `go test -race ./... -count=10` passes with no races.

Fixes #6