### PR TITLE
chore: support $eval

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.3]
+        go-version: [1.22.6]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/callable.go
+++ b/callable.go
@@ -48,7 +48,7 @@ func newGoCallableParam(typ reflect.Type) goCallableParam {
 		t: typ,
 	}
 
-	isOpt := reflect.PtrTo(typ).Implements(jtypes.TypeOptional)
+	isOpt := reflect.PointerTo(typ).Implements(jtypes.TypeOptional)
 	if isOpt {
 		o := reflect.New(typ).Interface().(jtypes.Optional)
 		p := newGoCallableParam(o.Type())
@@ -294,7 +294,7 @@ func (c *goCallable) validateArgTypes(argv []reflect.Value) ([]reflect.Value, er
 		// This is fine for most types but we need to restore
 		// pointer type Callables.
 		if v.Kind() == reflect.Struct &&
-			reflect.PtrTo(v.Type()).Implements(jtypes.TypeCallable) {
+			reflect.PointerTo(v.Type()).Implements(jtypes.TypeCallable) {
 			if v.CanAddr() {
 				v = v.Addr()
 			}

--- a/env.go
+++ b/env.go
@@ -179,6 +179,11 @@ var standardFunctions = map[string]Extension{
 		UndefinedHandler:   defaultUndefinedHandler,
 		EvalContextHandler: defaultContextHandler,
 	},
+	"eval": {
+		Func:               DoEval,
+		UndefinedHandler:   nil,
+		EvalContextHandler: func([]reflect.Value) bool { return true },
+	},
 
 	// Number functions
 

--- a/eval.go
+++ b/eval.go
@@ -1361,7 +1361,7 @@ func (s sequence) valueAt(idx int) reflect.Value {
 
 var (
 	typeSequence    = reflect.TypeOf((*sequence)(nil)).Elem()
-	typeSequencePtr = reflect.PtrTo(typeSequence)
+	typeSequencePtr = reflect.PointerTo(typeSequence)
 )
 
 func asSequence(v reflect.Value) (*sequence, bool) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stepzen-dev/jsonata-go
 
-go 1.20
+go 1.22
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/jlib/string_test.go
+++ b/jlib/string_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if !reflect.PtrTo(typeMatchCallable).Implements(typeCallable) {
+	if !reflect.PointerTo(typeMatchCallable).Implements(typeCallable) {
 		fmt.Fprintln(os.Stderr, "*matchCallable is not a Callable. Aborting...")
 		os.Exit(1)
 	}

--- a/jsonata_test.go
+++ b/jsonata_test.go
@@ -8168,3 +8168,31 @@ func TestFuncType(t *testing.T) {
 		},
 	})
 }
+
+func TestFuncEval(t *testing.T) {
+	runTestCases(t, testdata.account, []*testCase{
+		{
+			Expression: `$eval("[1,2,3]")`,
+			Output:     []any{1.0, 2.0, 3.0},
+		},
+		{
+			Expression: `$eval("10 + 32")`,
+			Output:     42.0,
+		},
+		{
+			// ensure default context is picked up
+			Expression: `$eval("Account.Order.OrderID")`,
+			Output:     []any{"order103", "order104"},
+		},
+		{
+			// ensure context can be overridden
+			Expression: `$eval("Order.OrderID", Account)`,
+			Output:     []any{"order103", "order104"},
+		},
+		{
+			// ensure context can be overridden
+			Expression: `$eval("a+b", {"a":8.4, "b": 33.6})`,
+			Output:     42.0,
+		},
+	})
+}

--- a/jtypes/funcs.go
+++ b/jtypes/funcs.go
@@ -44,7 +44,7 @@ func IsNumber(v reflect.Value) bool {
 func IsCallable(v reflect.Value) bool {
 	v = Resolve(v)
 	return v.IsValid() &&
-		(v.Type().Implements(TypeCallable) || reflect.PtrTo(v.Type()).Implements(TypeCallable))
+		(v.Type().Implements(TypeCallable) || reflect.PointerTo(v.Type()).Implements(TypeCallable))
 }
 
 // IsArray (golint)
@@ -128,7 +128,7 @@ func AsCallable(v reflect.Value) (Callable, bool) {
 		return v.Interface().(Callable), true
 	}
 
-	if v.IsValid() && reflect.PtrTo(v.Type()).Implements(TypeCallable) && v.CanAddr() && v.Addr().CanInterface() {
+	if v.IsValid() && reflect.PointerTo(v.Type()).Implements(TypeCallable) && v.CanAddr() && v.Addr().CanInterface() {
 		return v.Addr().Interface().(Callable), true
 	}
 


### PR DESCRIPTION
Passes the `$eval` tests from jsonata 1.6.1 (javascript)

Updated to golang 1.22 which required changing `reflect.PtrTo` to `reflect.PointerTo`.